### PR TITLE
Update oar.rst

### DIFF
--- a/doc/oar.rst
+++ b/doc/oar.rst
@@ -76,7 +76,7 @@ This feature is available with the ``-l walltime=<duration>`` option of the ``oa
 
 .. code-block:: bash
 
-   oarsub -l /nodes=4, walltime=02:30:00 ./myjob.sh
+   oarsub -l /nodes=4,walltime=02:30:00 ./myjob.sh
 
 in your terminal.
 


### PR DESCRIPTION
It must not be any space between the comma and the walltime variable in the resource list option of oarsub command. Otherwise, the command does not work.
